### PR TITLE
Add pester tests for get-help examples. 

### DIFF
--- a/Powershell.Helper.Extension.Tests.ps1
+++ b/Powershell.Helper.Extension.Tests.ps1
@@ -2,7 +2,6 @@
 $srcModule = $MyInvocation.MyCommand.Path `
     -replace '\.Tests\.', '.' -replace "ps1", "psd1"
 Import-Module $srcModule 
-$VerbosePreference="Continue"
 
 InModuleScope "Powershell.Helper.Extension" {
     Describe "Add-Path" {
@@ -54,7 +53,11 @@ InModuleScope "Powershell.Helper.Extension" {
                 }
             }
         }
-
+        Context "Test Get-Help"{
+            It "Can get-help and see examples" {
+                $(get-help Add-Path ).examples.example.Count -gt 0 | Should Be $true
+            }
+        }
     }
     Describe "Format-OrderedList" {
         Mock Read-Host { }
@@ -100,54 +103,67 @@ InModuleScope "Powershell.Helper.Extension" {
                 $getService | select -First 1 | Should Match $pattern
             }
         }
+        Context "Test Get-Help"{
+            It "Can get-help and see examples" {
+                $(get-help Format-OrderedList ).examples.example.Count -gt 0 | Should Be $true
+            }
+        }
+    
     }
     Describe "Limit-Job" {
-        
-        It "The method exists when calling Get-Command" {
-            !(Get-Command "Limit-Job" -errorAction SilentlyContinue) | Should Be $false
-        }  
-        It "Can start multiple Jobs" {
-            #Create a list of jobs to start 
-            $StartJob = @({start-job -ScriptBlock { sleep -Milliseconds 10 }},{start-job -ScriptBlock { sleep -Milliseconds 20 }},{start-job -ScriptBlock { sleep -Milliseconds 30 }}  )
-            $job = Limit-Job -StartJob $StartJob
-            $JobsCountAfter = get-job  
-            $JobsCountAfter.Count | Should Be $StartJob.Count
-        }              
-        It "Can start multiple commands as Jobs" {
-            #Create a list of jobs to start 
-            $StartJob = @({ sleep -Milliseconds 10 },{ sleep -Milliseconds 20 },{ sleep -Milliseconds 30 })
-            $job = Limit-Job -StartJob $StartJob
-            $JobsCountAfter = get-job  
-            $JobsCountAfter.Count | Should Be $StartJob.Count
-        }
-        It "Can limit how many jobs running to 1 " {
-            $StartJob = @({start-job -ScriptBlock { sleep -Milliseconds 101 }},{start-job -ScriptBlock { sleep -Milliseconds 1002 }},{start-job -ScriptBlock { sleep -Milliseconds 1003 }}  )
-            $Limit = 1
-            $job = Limit-Job -StartJob $StartJob -Limit $Limit
-            $JobsCountAfter = get-job -State Running 
-            $JobsCountAfter.Count | Should Be $Limit
+        Context "Test Limit-Job"{    
+            It "The method exists when calling Get-Command" {
+                !(Get-Command "Limit-Job" -errorAction SilentlyContinue) | Should Be $false
+            }  
+            It "Can start multiple Jobs" {
+                #Create a list of jobs to start 
+                $StartJob = @({start-job -ScriptBlock { sleep -Milliseconds 10 }},{start-job -ScriptBlock { sleep -Milliseconds 20 }},{start-job -ScriptBlock { sleep -Milliseconds 30 }}  )
+                $job = Limit-Job -StartJob $StartJob
+                $JobsCountAfter = get-job  
+                $JobsCountAfter.Count | Should Be $StartJob.Count
+            }              
+            It "Can start multiple commands as Jobs" {
+                #Create a list of jobs to start 
+                $StartJob = @({ sleep -Milliseconds 10 },{ sleep -Milliseconds 20 },{ sleep -Milliseconds 30 })
+                $job = Limit-Job -StartJob $StartJob
+                $JobsCountAfter = get-job  
+                $JobsCountAfter.Count | Should Be $StartJob.Count
+            }
+            It "Can limit how many jobs running to 1 " {
+                $StartJob = @({start-job -ScriptBlock { sleep -Milliseconds 101 }},{start-job -ScriptBlock { sleep -Milliseconds 1002 }},{start-job -ScriptBlock { sleep -Milliseconds 1003 }}  )
+                $Limit = 1
+                $job = Limit-Job -StartJob $StartJob -Limit $Limit
+                $JobsCountAfter = get-job -State Running 
+                $JobsCountAfter.Count | Should Be $Limit
 
-        }
-        It "Can limit how many jobs running to 2 " {
-            $StartJob = @({start-job -ScriptBlock { sleep -Milliseconds 0101 }},{start-job -ScriptBlock { sleep -Milliseconds 5002 }},{start-job -ScriptBlock { sleep -Milliseconds 5003 }}  )
-            $Limit = 2
-            Limit-Job -StartJob $StartJob -Limit $Limit
+            }
+            It "Can limit how many jobs running to 2 " {
+                $StartJob = @({start-job -ScriptBlock { sleep -Milliseconds 0101 }},{start-job -ScriptBlock { sleep -Milliseconds 5002 }},{start-job -ScriptBlock { sleep -Milliseconds 5003 }}  )
+                $Limit = 2
+                Limit-Job -StartJob $StartJob -Limit $Limit
             
-            $(get-job -State Running).Count | Should Be $Limit
+                $(get-job -State Running).Count | Should Be $Limit
 
+            }
+
+            BeforeEach{
+                #remove any jobs in this session
+                get-job | Stop-Job 
+                get-job | remove-job
+            }
+            AfterEach{
+                #remove any jobs in this session
+                get-job | Stop-Job 
+                get-job | remove-job
+
+            }
+        }
+        Context "Test Get-Help"{
+            It "Can get-help and see examples" {
+                $(get-help Limit-Job).examples.example.Count -gt 0 | Should Be $true
+            }
         }
 
-        BeforeEach{
-            #remove any jobs in this session
-            get-job | Stop-Job 
-            get-job | remove-job
-        }
-        AfterEach{
-            #remove any jobs in this session
-            get-job | Stop-Job 
-            get-job | remove-job
-
-        }
     }
 
 }

--- a/Powershell.Helper.Extension.psd1
+++ b/Powershell.Helper.Extension.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Powershell.Helper.Extension.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.7'
+ModuleVersion = '1.8'
 
 # ID used to uniquely identify this module
 GUID = 'd419801b-dfdf-44b3-a452-796f4c954172'
@@ -111,7 +111,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'Tried to add mocks for Add-Path (failed). Added functionality to handle UNC type path. Added Test to test UNC path.'
+        ReleaseNotes = 'Add pester tests for get-help examples. Moved the function documentation into the module functions. Fixed issue with Add-path not displaying examples. '
 
         # External dependent modules of this module
         # ExternalModuleDependencies = ''

--- a/Powershell.Helper.Extension.psm1
+++ b/Powershell.Helper.Extension.psm1
@@ -41,17 +41,23 @@ function Format-Item{
 
 }
 ############### Place external functions here alphabetically
-<#
-.DESCRIPTION 
-    Creates each level of a path. Requires elevated permissions to create a path. Currently, does not check if
-    adequate permissions exist to create a path.
-.EXAMPLE 1
-    Build-Path -Path "c:\temp\ouptut\Time0930"
-    Each portion of the path is checked, if it does not exist it is created.
 
-#>
 
 function Add-Path{
+    <#
+    .SYNOPSIS
+        when creating a new script the script sometimes needs to work with files or output files into specific folder structures.
+        Add-Path allows the developer to focus on the code, not the folder creation.    
+    .DESCRIPTION 
+        Creates each level of a path. Requires elevated permissions to create a path. Currently, does not check if
+        adequate permissions exist to create a path.
+    .EXAMPLE
+        Build-Path -Path "c:\temp\ouptut\Time0930"
+        Each portion of the path is checked, if it does not exist it is created.
+    .EXAMPLE
+        Build-Path -Path "\\servername\ShareName\NewFolder1\NewFolder2"
+
+    #>
     param([string]$Path)
     [string]$testPath = ""
     if(!(test-path $Path) ){        
@@ -81,246 +87,245 @@ function Add-Path{
     return [string]$Path
 }
 
-<#
-.SYNOPSIS
-    Many of powershells functions return streams or lists of items. This function allows the user to choose items by a number in
-    a list without have to sort by name. 
-
-.DESCRIPTION 
-    Format-NumberedList formats lists in to a numbered list, allowing user to choose one or more items in the list.  
-
-.EXAMPLE
-    PS> Get-Service | SELECT -First 100 | Format-OrderedList
-    1 :	Stopped	  AJRouter	  AllJoyn Router Service	 
-    2 :	Stopped	  ALG	  Application Layer Gateway Service	 
-    3 :	Running	  AppHostSvc	  Application Host Helper Service	 
-    4 :	Stopped	  AppIDSvc	  Application Identity	 
-    5 :	Running	  Appinfo	  Application Information	 
-    6 :	Stopped	  AppMgmt	  Application Management	 
-    7 :	Stopped	  AppReadiness	  App Readiness	 
-    8 :	Stopped	  AppXSvc	  AppX Deployment Service (AppXSVC)	 
-    9 :	Stopped	  aspnet_state	  ASP.NET State Service	 
-    10 :	Running	  Asset Management Daemon	  Asset Management Daemon	 
-    11 :	Running	  AudioEndpointBuilder	  Windows Audio Endpoint Builder	 
-    12 :	Running	  Audiosrv	  Windows Audio	 
-    13 :	Stopped	  AxInstSV	  ActiveX Installer (AxInstSV)	 
-    14 :	Stopped	  BDESVC	  BitLocker Drive Encryption Service	 
-    15 :	Running	  BFE	  Base Filtering Engine	 
-    16 :	Running	  BITS	  Background Intelligent Transfer Service	 
-    17 :	Running	  BrokerInfrastructure	  Background Tasks Infrastructure Service	 
-    18 :	Running	  Browser	  Computer Browser	 
-    19 :	Stopped	  BthHFSrv	  Bluetooth Handsfree Service	 
-    20 :	Running	  bthserv	  Bluetooth Support Service	 
-    21 :	Stopped	  CDPSvc	  Connected Device Platform Service	 
-    22 :	Stopped	  CertPropSvc	  Certificate Propagation	 
-    23 :	Running	  ClickToRunSvc	  Microsoft Office Click-to-Run Service	 
-    24 :	Stopped	  ClipSVC	  Client License Service (ClipSVC)	 
-    25 :	Stopped	  COMSysApp	  COM+ System Application	 
-    26 :	Running	  CoreMessagingRegistrar	  CoreMessaging	 
-    27 :	Stopped	  cphs	  Intel(R) Content Protection HECI Service	 
-    28 :	Running	  CryptSvc	  Cryptographic Services	 
-    29 :	Running	  CscService	  Offline Files	 
-    30 :	Running	  DcomLaunch	  DCOM Server Process Launcher	 
-    31 :	Stopped	  DcpSvc	  DataCollectionPublishingService	 
-    32 :	Stopped	  defragsvc	  Optimize drives	 
-    33 :	Running	  DeviceAssociationService	  Device Association Service	 
-    34 :	Stopped	  DeviceInstall	  Device Install Service	 
-    35 :	Stopped	  DevQueryBroker	  DevQuery Background Discovery Broker	 
-    36 :	Running	  Dhcp	  DHCP Client	 
-    37 :	Stopped	  diagnosticshub.standardcollector.service	  Microsoft (R) Diagnostics Hub Standard Collector Service	 
-    38 :	Running	  DiagTrack	  Connected User Experiences and Telemetry	 
-    39 :	Stopped	  DmEnrollmentSvc	  Device Management Enrollment Service	 
-    40 :	Stopped	  dmwappushservice	  dmwappushsvc	 
-    41 :	Stopped	  Dnscache	  DNS Client	 
-    42 :	Running	  DoSvc	  Delivery Optimization	 
-    43 :	Stopped	  dot3svc	  Wired AutoConfig	 
-    44 :	Running	  DPS	  Diagnostic Policy Service	 
-    45 :	Stopped	  DsmSvc	  Device Setup Manager	 
-    46 :	Running	  DsSvc	  Data Sharing Service	 
-    47 :	Running	  DTSRVC	  Portrait Displays Display Tune Service	 
-    48 :	Stopped	  Eaphost	  Extensible Authentication Protocol	 
-    49 :	Stopped	  EFS	  Encrypting File System (EFS)	 
-    50 :	Stopped	  embeddedmode	  embeddedmode	 
-    51 :	Stopped	  EntAppSvc	  Enterprise App Management Service	 
-    52 :	Running	  EventLog	  Windows Event Log	 
-    53 :	Running	  EventSystem	  COM+ Event System	 
-    54 :	Running	  FA_Scheduler	  FortiClient Service Scheduler	 
-    55 :	Stopped	  Fax	  Fax	 
-    56 :	Stopped	  fdPHost	  Function Discovery Provider Host	 
-    57 :	Stopped	  FDResPub	  Function Discovery Resource Publication	 
-    58 :	Stopped	  fhsvc	  File History Service	 
-    59 :	Running	  FontCache	  Windows Font Cache Service	 
-    60 :	Running	  FontCache3.0.0.0	  Windows Presentation Foundation Font Cache 3.0.0.0	 
-    61 :	Stopped	  gpsvc	  Group Policy Client	 
-    62 :	Stopped	  gupdate	  Google Update Service (gupdate)	 
-    63 :	Stopped	  gupdatem	  Google Update Service (gupdatem)	 
-    64 :	Running	  hidserv	  Human Interface Device Service	 
-    65 :	Stopped	  HomeGroupProvider	  HomeGroup Provider	 
-    66 :	Running	  HvHost	  HV Host Service	 
-    67 :	Running	  IBMPMSVC	  Lenovo PM Service	 
-    68 :	Stopped	  icssvc	  Windows Mobile Hotspot Service	 
-    69 :	Stopped	  IEEtwCollectorService	  Internet Explorer ETW Collector Service	 
-    70 :	Running	  igfxCUIService2.0.0.0	  Intel(R) HD Graphics Control Panel Service	 
-    71 :	Running	  IKEEXT	  IKE and AuthIP IPsec Keying Modules	 
-    72 :	Stopped	  Intel(R) Capability Licensing Service TCP IP Interface	  Intel(R) Capability Licensing Service TCP IP Interface	 
-    73 :	Running	  iphlpsvc	  IP Helper	 
-    74 :	Running	  jhi_service	  Intel(R) Dynamic Application Loader Host Interface Service	 
-    75 :	Running	  KeyIso	  CNG Key Isolation	 
-    76 :	Stopped	  KtmRm	  KtmRm for Distributed Transaction Coordinator	 
-    77 :	Running	  LanmanServer	  Server	 
-    78 :	Running	  LanmanWorkstation	  Workstation	 
-    79 :	Running	  LENOVO.CAMMUTE	  Lenovo Camera Mute	 
-    80 :	Running	  LENOVO.MICMUTE	  Lenovo Microphone Mute	 
-    81 :	Running	  LENOVO.TPKNRSVC	  Lenovo Keyboard Noise Reduction	 
-    82 :	Running	  LENOVO.TVTVCAM	  Lenovo Virtual Camera Controller	 
-    83 :	Running	  Lenovo.VIRTSCRLSVC	  Lenovo Auto Scroll	 
-    84 :	Stopped	  LenovoProdRegManager	  PowerENGAGE Maintenance Service	 
-    85 :	Running	  lfsvc	  Geolocation Service	 
-    86 :	Running	  LicenseManager	  Windows License Manager Service	 
-    87 :	Stopped	  lltdsvc	  Link-Layer Topology Discovery Mapper	 
-    88 :	Running	  lmhosts	  TCP/IP NetBIOS Helper	 
-    89 :	Running	  LMS	  Intel(R) Management and Security Application Local Management Service	 
-    90 :	Running	  lnvDiscoveryWinSvc	  lnvDiscoveryWinSvc	 
-    91 :	Stopped	  LSCWinService	  LSCWinService	 
-    92 :	Running	  LSM	  Local Session Manager	 
-    93 :	Stopped	  MapsBroker	  Downloaded Maps Manager	 
-    94 :	Running	  MpsSvc	  Windows Firewall	 
-    95 :	Stopped	  MSDTC	  Distributed Transaction Coordinator	 
-    96 :	Stopped	  MSiSCSI	  Microsoft iSCSI Initiator Service	 
-    97 :	Stopped	  msiserver	  Windows Installer	 
-    98 :	Running	  MSMQ	  Message Queuing	 
-    99 :	Stopped	  NcaSvc	  Network Connectivity Assistant	 
-    100 :	Running	  NcbService	  Network Connection Broker	 
-	    Choose an item by #
-    [0] : 1
-    [1] : 10
-    [2] : 100
-    [3] : 
-
-    Status   Name               DisplayName                           
-    ------   ----               -----------                           
-    Stopped  AJRouter           AllJoyn Router Service                
-    Running  Asset Managemen... Asset Management Daemon               
-    Running  NcbService         Network Connection Broker  
-
-.EXAMPLE
-    PS> Get-Service  | SELECT -First 100 | Format-OrderedList -property Name
-    1 :	AJRouter	 
-    2 :	ALG	 
-    3 :	AppHostSvc	 
-    4 :	AppIDSvc	 
-    5 :	Appinfo	 
-    6 :	AppMgmt	 
-    7 :	AppReadiness	 
-    8 :	AppXSvc	 
-    9 :	aspnet_state	 
-    10 :	Asset Management Daemon	 
-    11 :	AudioEndpointBuilder	 
-    12 :	Audiosrv	 
-    13 :	AxInstSV	 
-    14 :	BDESVC	 
-    15 :	BFE	 
-    16 :	BITS	 
-    17 :	BrokerInfrastructure	 
-    18 :	Browser	 
-    19 :	BthHFSrv	 
-    20 :	bthserv	 
-    21 :	CDPSvc	 
-    22 :	CertPropSvc	 
-    23 :	ClickToRunSvc	 
-    24 :	ClipSVC	 
-    25 :	COMSysApp	 
-    26 :	CoreMessagingRegistrar	 
-    27 :	cphs	 
-    28 :	CryptSvc	 
-    29 :	CscService	 
-    30 :	DcomLaunch	 
-    31 :	DcpSvc	 
-    32 :	defragsvc	 
-    33 :	DeviceAssociationService	 
-    34 :	DeviceInstall	 
-    35 :	DevQueryBroker	 
-    36 :	Dhcp	 
-    37 :	diagnosticshub.standardcollector.service	 
-    38 :	DiagTrack	 
-    39 :	DmEnrollmentSvc	 
-    40 :	dmwappushservice	 
-    41 :	Dnscache	 
-    42 :	DoSvc	 
-    43 :	dot3svc	 
-    44 :	DPS	 
-    45 :	DsmSvc	 
-    46 :	DsSvc	 
-    47 :	DTSRVC	 
-    48 :	Eaphost	 
-    49 :	EFS	 
-    50 :	embeddedmode	 
-    51 :	EntAppSvc	 
-    52 :	EventLog	 
-    53 :	EventSystem	 
-    54 :	FA_Scheduler	 
-    55 :	Fax	 
-    56 :	fdPHost	 
-    57 :	FDResPub	 
-    58 :	fhsvc	 
-    59 :	FontCache	 
-    60 :	FontCache3.0.0.0	 
-    61 :	gpsvc	 
-    62 :	gupdate	 
-    63 :	gupdatem	 
-    64 :	hidserv	 
-    65 :	HomeGroupProvider	 
-    66 :	HvHost	 
-    67 :	IBMPMSVC	 
-    68 :	icssvc	 
-    69 :	IEEtwCollectorService	 
-    70 :	igfxCUIService2.0.0.0	 
-    71 :	IKEEXT	 
-    72 :	Intel(R) Capability Licensing Service TCP IP Interface	 
-    73 :	iphlpsvc	 
-    74 :	jhi_service	 
-    75 :	KeyIso	 
-    76 :	KtmRm	 
-    77 :	LanmanServer	 
-    78 :	LanmanWorkstation	 
-    79 :	LENOVO.CAMMUTE	 
-    80 :	LENOVO.MICMUTE	 
-    81 :	LENOVO.TPKNRSVC	 
-    82 :	LENOVO.TVTVCAM	 
-    83 :	Lenovo.VIRTSCRLSVC	 
-    84 :	LenovoProdRegManager	 
-    85 :	lfsvc	 
-    86 :	LicenseManager	 
-    87 :	lltdsvc	 
-    88 :	lmhosts	 
-    89 :	LMS	 
-    90 :	lnvDiscoveryWinSvc	 
-    91 :	LSCWinService	 
-    92 :	LSM	 
-    93 :	MapsBroker	 
-    94 :	MpsSvc	 
-    95 :	MSDTC	 
-    96 :	MSiSCSI	 
-    97 :	msiserver	 
-    98 :	MSMQ	 
-    99 :	NcaSvc	 
-    100 :	NcbService	 
-	    Choose an item by #
-    [0] : 5
-    [1] : 10
-    [2] : 16
-    [3] : 25
-    [4] : 
-
-    Status   Name               DisplayName                           
-    ------   ----               -----------                           
-    Running  Appinfo            Application Information               
-    Running  Asset Managemen... Asset Management Daemon               
-    Running  BITS               Background Intelligent Transfer Ser...
-    Stopped  COMSysApp          COM+ System Application 
-#>
-
 function Format-OrderedList{
+    <#
+    .SYNOPSIS
+        Many of powershells functions return streams or lists of items. This function allows the user to choose items by a number in
+        a list without have to sort by name. 
+
+    .DESCRIPTION 
+        Format-NumberedList formats lists in to a numbered list, allowing user to choose one or more items in the list.  
+
+    .EXAMPLE
+        PS> Get-Service | SELECT -First 100 | Format-OrderedList
+        1 :	Stopped	  AJRouter	  AllJoyn Router Service	 
+        2 :	Stopped	  ALG	  Application Layer Gateway Service	 
+        3 :	Running	  AppHostSvc	  Application Host Helper Service	 
+        4 :	Stopped	  AppIDSvc	  Application Identity	 
+        5 :	Running	  Appinfo	  Application Information	 
+        6 :	Stopped	  AppMgmt	  Application Management	 
+        7 :	Stopped	  AppReadiness	  App Readiness	 
+        8 :	Stopped	  AppXSvc	  AppX Deployment Service (AppXSVC)	 
+        9 :	Stopped	  aspnet_state	  ASP.NET State Service	 
+        10 :	Running	  Asset Management Daemon	  Asset Management Daemon	 
+        11 :	Running	  AudioEndpointBuilder	  Windows Audio Endpoint Builder	 
+        12 :	Running	  Audiosrv	  Windows Audio	 
+        13 :	Stopped	  AxInstSV	  ActiveX Installer (AxInstSV)	 
+        14 :	Stopped	  BDESVC	  BitLocker Drive Encryption Service	 
+        15 :	Running	  BFE	  Base Filtering Engine	 
+        16 :	Running	  BITS	  Background Intelligent Transfer Service	 
+        17 :	Running	  BrokerInfrastructure	  Background Tasks Infrastructure Service	 
+        18 :	Running	  Browser	  Computer Browser	 
+        19 :	Stopped	  BthHFSrv	  Bluetooth Handsfree Service	 
+        20 :	Running	  bthserv	  Bluetooth Support Service	 
+        21 :	Stopped	  CDPSvc	  Connected Device Platform Service	 
+        22 :	Stopped	  CertPropSvc	  Certificate Propagation	 
+        23 :	Running	  ClickToRunSvc	  Microsoft Office Click-to-Run Service	 
+        24 :	Stopped	  ClipSVC	  Client License Service (ClipSVC)	 
+        25 :	Stopped	  COMSysApp	  COM+ System Application	 
+        26 :	Running	  CoreMessagingRegistrar	  CoreMessaging	 
+        27 :	Stopped	  cphs	  Intel(R) Content Protection HECI Service	 
+        28 :	Running	  CryptSvc	  Cryptographic Services	 
+        29 :	Running	  CscService	  Offline Files	 
+        30 :	Running	  DcomLaunch	  DCOM Server Process Launcher	 
+        31 :	Stopped	  DcpSvc	  DataCollectionPublishingService	 
+        32 :	Stopped	  defragsvc	  Optimize drives	 
+        33 :	Running	  DeviceAssociationService	  Device Association Service	 
+        34 :	Stopped	  DeviceInstall	  Device Install Service	 
+        35 :	Stopped	  DevQueryBroker	  DevQuery Background Discovery Broker	 
+        36 :	Running	  Dhcp	  DHCP Client	 
+        37 :	Stopped	  diagnosticshub.standardcollector.service	  Microsoft (R) Diagnostics Hub Standard Collector Service	 
+        38 :	Running	  DiagTrack	  Connected User Experiences and Telemetry	 
+        39 :	Stopped	  DmEnrollmentSvc	  Device Management Enrollment Service	 
+        40 :	Stopped	  dmwappushservice	  dmwappushsvc	 
+        41 :	Stopped	  Dnscache	  DNS Client	 
+        42 :	Running	  DoSvc	  Delivery Optimization	 
+        43 :	Stopped	  dot3svc	  Wired AutoConfig	 
+        44 :	Running	  DPS	  Diagnostic Policy Service	 
+        45 :	Stopped	  DsmSvc	  Device Setup Manager	 
+        46 :	Running	  DsSvc	  Data Sharing Service	 
+        47 :	Running	  DTSRVC	  Portrait Displays Display Tune Service	 
+        48 :	Stopped	  Eaphost	  Extensible Authentication Protocol	 
+        49 :	Stopped	  EFS	  Encrypting File System (EFS)	 
+        50 :	Stopped	  embeddedmode	  embeddedmode	 
+        51 :	Stopped	  EntAppSvc	  Enterprise App Management Service	 
+        52 :	Running	  EventLog	  Windows Event Log	 
+        53 :	Running	  EventSystem	  COM+ Event System	 
+        54 :	Running	  FA_Scheduler	  FortiClient Service Scheduler	 
+        55 :	Stopped	  Fax	  Fax	 
+        56 :	Stopped	  fdPHost	  Function Discovery Provider Host	 
+        57 :	Stopped	  FDResPub	  Function Discovery Resource Publication	 
+        58 :	Stopped	  fhsvc	  File History Service	 
+        59 :	Running	  FontCache	  Windows Font Cache Service	 
+        60 :	Running	  FontCache3.0.0.0	  Windows Presentation Foundation Font Cache 3.0.0.0	 
+        61 :	Stopped	  gpsvc	  Group Policy Client	 
+        62 :	Stopped	  gupdate	  Google Update Service (gupdate)	 
+        63 :	Stopped	  gupdatem	  Google Update Service (gupdatem)	 
+        64 :	Running	  hidserv	  Human Interface Device Service	 
+        65 :	Stopped	  HomeGroupProvider	  HomeGroup Provider	 
+        66 :	Running	  HvHost	  HV Host Service	 
+        67 :	Running	  IBMPMSVC	  Lenovo PM Service	 
+        68 :	Stopped	  icssvc	  Windows Mobile Hotspot Service	 
+        69 :	Stopped	  IEEtwCollectorService	  Internet Explorer ETW Collector Service	 
+        70 :	Running	  igfxCUIService2.0.0.0	  Intel(R) HD Graphics Control Panel Service	 
+        71 :	Running	  IKEEXT	  IKE and AuthIP IPsec Keying Modules	 
+        72 :	Stopped	  Intel(R) Capability Licensing Service TCP IP Interface	  Intel(R) Capability Licensing Service TCP IP Interface	 
+        73 :	Running	  iphlpsvc	  IP Helper	 
+        74 :	Running	  jhi_service	  Intel(R) Dynamic Application Loader Host Interface Service	 
+        75 :	Running	  KeyIso	  CNG Key Isolation	 
+        76 :	Stopped	  KtmRm	  KtmRm for Distributed Transaction Coordinator	 
+        77 :	Running	  LanmanServer	  Server	 
+        78 :	Running	  LanmanWorkstation	  Workstation	 
+        79 :	Running	  LENOVO.CAMMUTE	  Lenovo Camera Mute	 
+        80 :	Running	  LENOVO.MICMUTE	  Lenovo Microphone Mute	 
+        81 :	Running	  LENOVO.TPKNRSVC	  Lenovo Keyboard Noise Reduction	 
+        82 :	Running	  LENOVO.TVTVCAM	  Lenovo Virtual Camera Controller	 
+        83 :	Running	  Lenovo.VIRTSCRLSVC	  Lenovo Auto Scroll	 
+        84 :	Stopped	  LenovoProdRegManager	  PowerENGAGE Maintenance Service	 
+        85 :	Running	  lfsvc	  Geolocation Service	 
+        86 :	Running	  LicenseManager	  Windows License Manager Service	 
+        87 :	Stopped	  lltdsvc	  Link-Layer Topology Discovery Mapper	 
+        88 :	Running	  lmhosts	  TCP/IP NetBIOS Helper	 
+        89 :	Running	  LMS	  Intel(R) Management and Security Application Local Management Service	 
+        90 :	Running	  lnvDiscoveryWinSvc	  lnvDiscoveryWinSvc	 
+        91 :	Stopped	  LSCWinService	  LSCWinService	 
+        92 :	Running	  LSM	  Local Session Manager	 
+        93 :	Stopped	  MapsBroker	  Downloaded Maps Manager	 
+        94 :	Running	  MpsSvc	  Windows Firewall	 
+        95 :	Stopped	  MSDTC	  Distributed Transaction Coordinator	 
+        96 :	Stopped	  MSiSCSI	  Microsoft iSCSI Initiator Service	 
+        97 :	Stopped	  msiserver	  Windows Installer	 
+        98 :	Running	  MSMQ	  Message Queuing	 
+        99 :	Stopped	  NcaSvc	  Network Connectivity Assistant	 
+        100 :	Running	  NcbService	  Network Connection Broker	 
+	        Choose an item by #
+        [0] : 1
+        [1] : 10
+        [2] : 100
+        [3] : 
+
+        Status   Name               DisplayName                           
+        ------   ----               -----------                           
+        Stopped  AJRouter           AllJoyn Router Service                
+        Running  Asset Managemen... Asset Management Daemon               
+        Running  NcbService         Network Connection Broker  
+
+    .EXAMPLE
+        PS> Get-Service  | SELECT -First 100 | Format-OrderedList -property Name
+        1 :	AJRouter	 
+        2 :	ALG	 
+        3 :	AppHostSvc	 
+        4 :	AppIDSvc	 
+        5 :	Appinfo	 
+        6 :	AppMgmt	 
+        7 :	AppReadiness	 
+        8 :	AppXSvc	 
+        9 :	aspnet_state	 
+        10 :	Asset Management Daemon	 
+        11 :	AudioEndpointBuilder	 
+        12 :	Audiosrv	 
+        13 :	AxInstSV	 
+        14 :	BDESVC	 
+        15 :	BFE	 
+        16 :	BITS	 
+        17 :	BrokerInfrastructure	 
+        18 :	Browser	 
+        19 :	BthHFSrv	 
+        20 :	bthserv	 
+        21 :	CDPSvc	 
+        22 :	CertPropSvc	 
+        23 :	ClickToRunSvc	 
+        24 :	ClipSVC	 
+        25 :	COMSysApp	 
+        26 :	CoreMessagingRegistrar	 
+        27 :	cphs	 
+        28 :	CryptSvc	 
+        29 :	CscService	 
+        30 :	DcomLaunch	 
+        31 :	DcpSvc	 
+        32 :	defragsvc	 
+        33 :	DeviceAssociationService	 
+        34 :	DeviceInstall	 
+        35 :	DevQueryBroker	 
+        36 :	Dhcp	 
+        37 :	diagnosticshub.standardcollector.service	 
+        38 :	DiagTrack	 
+        39 :	DmEnrollmentSvc	 
+        40 :	dmwappushservice	 
+        41 :	Dnscache	 
+        42 :	DoSvc	 
+        43 :	dot3svc	 
+        44 :	DPS	 
+        45 :	DsmSvc	 
+        46 :	DsSvc	 
+        47 :	DTSRVC	 
+        48 :	Eaphost	 
+        49 :	EFS	 
+        50 :	embeddedmode	 
+        51 :	EntAppSvc	 
+        52 :	EventLog	 
+        53 :	EventSystem	 
+        54 :	FA_Scheduler	 
+        55 :	Fax	 
+        56 :	fdPHost	 
+        57 :	FDResPub	 
+        58 :	fhsvc	 
+        59 :	FontCache	 
+        60 :	FontCache3.0.0.0	 
+        61 :	gpsvc	 
+        62 :	gupdate	 
+        63 :	gupdatem	 
+        64 :	hidserv	 
+        65 :	HomeGroupProvider	 
+        66 :	HvHost	 
+        67 :	IBMPMSVC	 
+        68 :	icssvc	 
+        69 :	IEEtwCollectorService	 
+        70 :	igfxCUIService2.0.0.0	 
+        71 :	IKEEXT	 
+        72 :	Intel(R) Capability Licensing Service TCP IP Interface	 
+        73 :	iphlpsvc	 
+        74 :	jhi_service	 
+        75 :	KeyIso	 
+        76 :	KtmRm	 
+        77 :	LanmanServer	 
+        78 :	LanmanWorkstation	 
+        79 :	LENOVO.CAMMUTE	 
+        80 :	LENOVO.MICMUTE	 
+        81 :	LENOVO.TPKNRSVC	 
+        82 :	LENOVO.TVTVCAM	 
+        83 :	Lenovo.VIRTSCRLSVC	 
+        84 :	LenovoProdRegManager	 
+        85 :	lfsvc	 
+        86 :	LicenseManager	 
+        87 :	lltdsvc	 
+        88 :	lmhosts	 
+        89 :	LMS	 
+        90 :	lnvDiscoveryWinSvc	 
+        91 :	LSCWinService	 
+        92 :	LSM	 
+        93 :	MapsBroker	 
+        94 :	MpsSvc	 
+        95 :	MSDTC	 
+        96 :	MSiSCSI	 
+        97 :	msiserver	 
+        98 :	MSMQ	 
+        99 :	NcaSvc	 
+        100 :	NcbService	 
+	        Choose an item by #
+        [0] : 5
+        [1] : 10
+        [2] : 16
+        [3] : 25
+        [4] : 
+
+        Status   Name               DisplayName                           
+        ------   ----               -----------                           
+        Running  Appinfo            Application Information               
+        Running  Asset Managemen... Asset Management Daemon               
+        Running  BITS               Background Intelligent Transfer Ser...
+        Stopped  COMSysApp          COM+ System Application 
+    #>
 param( [array]$property )
 begin{
     if($property){

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ and to increase proficiency in Git repositories and continue to build powershell
 4/17/2016: v1.6 - Added pester test for format-OrderedList. Fix bug where Format-OrderList would be empty if a propery was not specified. 
 
 4/23/2016: v1.7 - Added functionality to handle UNC type path. Added Test to test UNC path.
+
+4/24/2016: v1.8 - Add pester tests for get-help examples. Moved the function documentation into the module functions. Fixed issue with Add-path not displaying examples. 


### PR DESCRIPTION
Moved the function documentation into the module functions. Fixed issue with Add-path not displaying examples.

Resolved Issue #12 
